### PR TITLE
Exclude source code out of installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # compiled output
 dist/*
+electron.js
 
 # dependencies
 node_modules/*

--- a/builder/packager.js
+++ b/builder/packager.js
@@ -28,7 +28,7 @@ switch (process.env.NODE_OS) {
 			console.log('Successfully removed ./mac_packager/');
 		}
 		console.log('Creating mac packager...');
-		exec("cross-env NODE_ENV=prod webpack && electron-packager . --overwrite --platform=" + spec['platform']['mac'] + " --arch=" + spec['arch']['64'] + " --prune=true --out=mac_packager --icon=builder/icons/mac/icon.icns", (error) => {
+		exec("cross-env NODE_ENV=prod webpack && electron-packager dist --overwrite --platform=" + spec['platform']['mac'] + " --arch=" + spec['arch']['64'] + " --prune=true --out=mac_packager --icon=builder/icons/mac/icon.icns", (error) => {
 			if (!error) {
 				console.log('Successfully created packager at ./mac_packager/');
 			} else {
@@ -43,7 +43,7 @@ switch (process.env.NODE_OS) {
 			console.log('Successfully removed ./linux_packager/');
 		}
 		console.log('Creating linux packager...');
-		exec("cross-env NODE_ENV=prod webpack && electron-packager . --overwrite --platform=" + spec['platform']['linux'] + " --arch=" + spec['arch']['64'] + " --prune=true --out=linux_packager --icon=builder/icons/linux/icon.png", (error) => {
+		exec("cross-env NODE_ENV=prod webpack && electron-packager dist --overwrite --platform=" + spec['platform']['linux'] + " --arch=" + spec['arch']['64'] + " --prune=true --out=linux_packager --icon=builder/icons/linux/icon.png", (error) => {
 			if (!error) {
 				console.log('Successfully created packager at ./linux_packager/');
 			} else {
@@ -58,7 +58,7 @@ switch (process.env.NODE_OS) {
 			console.log('Successfully removed ./win_packager/');
 		}
 		console.log('Creating windows packager...');
-		exec("cross-env NODE_ENV=prod webpack && electron-packager . --overwrite --platform=" + spec['platform']['win'] + " --arch=" + spec['arch']['64'] + " --prune=true --out=win_packager --icon=builder/icons/win/icon.ico", (error) => {
+		exec("cross-env NODE_ENV=prod webpack && electron-packager dist --overwrite --platform=" + spec['platform']['win'] + " --arch=" + spec['arch']['64'] + " --prune=true --out=win_packager --icon=builder/icons/win/icon.ico", (error) => {
 			if (!error) {
 				console.log('Successfully created packager at ./win_packager/');
 			} else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -283,6 +283,12 @@
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
 			"dev": true
 		},
+		"array-buffer-from-string": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/array-buffer-from-string/-/array-buffer-from-string-0.1.0.tgz",
+			"integrity": "sha1-OxQ1H4YUnYTvxhLFrafthRadewc=",
+			"optional": true
+		},
 		"array-differ": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
@@ -331,10 +337,17 @@
 			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
 			"dev": true
 		},
+		"arrify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
+		},
 		"asar": {
 			"version": "0.13.1",
 			"resolved": "https://registry.npmjs.org/asar/-/asar-0.13.1.tgz",
 			"integrity": "sha512-HJnZadTbDVDhBDv3tMyDov3ZnwMYYmz80/+a7S6cFPvulUyRz55UG5hOyHeWSP1iZud6vjFq8GOYM6xxtxJECQ==",
+			"dev": true,
 			"requires": {
 				"chromium-pickle-js": "0.2.0",
 				"commander": "2.11.0",
@@ -349,12 +362,14 @@
 				"commander": {
 					"version": "2.11.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+					"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+					"dev": true
 				},
 				"glob": {
 					"version": "6.0.4",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
 					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+					"dev": true,
 					"requires": {
 						"inflight": "1.0.6",
 						"inherits": "2.0.3",
@@ -405,6 +420,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
 			"integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+			"dev": true,
 			"requires": {
 				"lodash": "4.17.4"
 			}
@@ -441,8 +457,7 @@
 		"attempt-x": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/attempt-x/-/attempt-x-1.1.1.tgz",
-			"integrity": "sha512-hIp37ojJRRW8ExWSxxLpkDHUufk/DFfsb7/cUC1cVbBg7JV4gJTkCTRa44dlL9e5jx1P3VNrjL7QOQfi4MyltA==",
-			"dev": true
+			"integrity": "sha512-hIp37ojJRRW8ExWSxxLpkDHUufk/DFfsb7/cUC1cVbBg7JV4gJTkCTRa44dlL9e5jx1P3VNrjL7QOQfi4MyltA=="
 		},
 		"author-regex": {
 			"version": "1.0.0",
@@ -525,6 +540,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+		},
+		"base32-encode": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/base32-encode/-/base32-encode-0.1.1.tgz",
+			"integrity": "sha512-jjc+6TC8PXrsxJ4CQr9ibioNhhAM1p/RvS9hy3Q+cxPphvXmLnFSkXoen2XXzNBrYjdmzajRtbFDl1x28F5F4A==",
+			"optional": true
 		},
 		"base64-js": {
 			"version": "1.2.1",
@@ -740,6 +761,15 @@
 				"hoek": "4.2.0"
 			}
 		},
+		"bplist-creator": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
+			"integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
+			"optional": true,
+			"requires": {
+				"stream-buffers": "2.2.0"
+			}
+		},
 		"brace-expansion": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
@@ -861,7 +891,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.1.tgz",
 			"integrity": "sha1-V7GLHaChnsBvM4N6UnWiQjUb114=",
-			"dev": true,
 			"requires": {
 				"is-array-buffer-x": "1.7.0"
 			}
@@ -950,8 +979,7 @@
 		"cached-constructors-x": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/cached-constructors-x/-/cached-constructors-x-1.0.0.tgz",
-			"integrity": "sha512-JVP0oilYlPgBTD8bkQ+of7hSIJRtydCCJiMtzdRMXVQ98gdj0NyrJTZzbu5wtlO26Ev/1HXRTtbBNsVlLJ3+3A==",
-			"dev": true
+			"integrity": "sha512-JVP0oilYlPgBTD8bkQ+of7hSIJRtydCCJiMtzdRMXVQ98gdj0NyrJTZzbu5wtlO26Ev/1HXRTtbBNsVlLJ3+3A=="
 		},
 		"camel-case": {
 			"version": "3.0.0",
@@ -1083,6 +1111,7 @@
 			"requires": {
 				"anymatch": "1.3.2",
 				"async-each": "1.0.1",
+				"fsevents": "1.2.3",
 				"glob-parent": "2.0.0",
 				"inherits": "2.0.3",
 				"is-binary-path": "1.0.1",
@@ -1100,7 +1129,8 @@
 		"chromium-pickle-js": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
-			"integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU="
+			"integrity": "sha1-BKEGZywYsIWrd02YPfo+oTjyIgU=",
+			"dev": true
 		},
 		"cipher-base": {
 			"version": "1.0.4",
@@ -1509,6 +1539,133 @@
 				"run-queue": "1.0.3"
 			}
 		},
+		"copy-webpack-plugin": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.5.1.tgz",
+			"integrity": "sha512-OlTo6DYg0XfTKOF8eLf79wcHm4Ut10xU2cRBRPMW/NA5F9VMjZGTfRHWDIYC3s+1kObGYrBLshXWU1K0hILkNQ==",
+			"dev": true,
+			"requires": {
+				"cacache": "10.0.4",
+				"find-cache-dir": "1.0.0",
+				"globby": "7.1.1",
+				"is-glob": "4.0.0",
+				"loader-utils": "1.1.0",
+				"minimatch": "3.0.4",
+				"p-limit": "1.1.0",
+				"serialize-javascript": "1.5.0"
+			},
+			"dependencies": {
+				"cacache": {
+					"version": "10.0.4",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+					"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
+					"dev": true,
+					"requires": {
+						"bluebird": "3.5.1",
+						"chownr": "1.0.1",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"lru-cache": "4.1.1",
+						"mississippi": "2.0.0",
+						"mkdirp": "0.5.1",
+						"move-concurrently": "1.0.1",
+						"promise-inflight": "1.0.1",
+						"rimraf": "2.6.2",
+						"ssri": "5.3.0",
+						"unique-filename": "1.1.0",
+						"y18n": "4.0.0"
+					}
+				},
+				"globby": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+					"integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+					"dev": true,
+					"requires": {
+						"array-union": "1.0.2",
+						"dir-glob": "2.0.0",
+						"glob": "7.1.2",
+						"ignore": "3.3.8",
+						"pify": "3.0.0",
+						"slash": "1.0.0"
+					}
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "2.1.1"
+					}
+				},
+				"mississippi": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/mississippi/-/mississippi-2.0.0.tgz",
+					"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
+					"dev": true,
+					"requires": {
+						"concat-stream": "1.6.0",
+						"duplexify": "3.5.1",
+						"end-of-stream": "1.4.0",
+						"flush-write-stream": "1.0.2",
+						"from2": "2.3.0",
+						"parallel-transform": "1.1.0",
+						"pump": "2.0.1",
+						"pumpify": "1.3.5",
+						"stream-each": "1.2.2",
+						"through2": "2.0.3"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				},
+				"pump": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+					"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+					"dev": true,
+					"requires": {
+						"end-of-stream": "1.4.0",
+						"once": "1.4.0"
+					}
+				},
+				"ssri": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+					"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"through2": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+					"dev": true,
+					"requires": {
+						"readable-stream": "2.3.3",
+						"xtend": "4.0.1"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"dev": true
+				}
+			}
+		},
 		"core-js": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
@@ -1540,6 +1697,21 @@
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
 				}
+			}
+		},
+		"cp-file": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/cp-file/-/cp-file-3.2.0.tgz",
+			"integrity": "sha1-b4NhYlRiTwrViqSqjQdvAmvn4Yg=",
+			"optional": true,
+			"requires": {
+				"graceful-fs": "4.1.11",
+				"mkdirp": "0.5.1",
+				"nested-error-stacks": "1.0.2",
+				"object-assign": "4.1.1",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"readable-stream": "2.3.3"
 			}
 		},
 		"create-ecdh": {
@@ -1601,9 +1773,20 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+			"dev": true,
 			"requires": {
 				"lru-cache": "4.1.1",
 				"shebang-command": "1.2.0",
+				"which": "1.3.0"
+			}
+		},
+		"cross-spawn-async": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+			"integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
+			"optional": true,
+			"requires": {
+				"lru-cache": "4.1.1",
 				"which": "1.3.0"
 			}
 		},
@@ -2272,6 +2455,33 @@
 				"randombytes": "2.0.5"
 			}
 		},
+		"dir-glob": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+			"integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+			"dev": true,
+			"requires": {
+				"arrify": "1.0.1",
+				"path-type": "3.0.0"
+			},
+			"dependencies": {
+				"path-type": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+					"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+					"dev": true,
+					"requires": {
+						"pify": "3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+					"dev": true
+				}
+			}
+		},
 		"dns-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -2386,6 +2596,17 @@
 				"ware": "1.3.0"
 			}
 		},
+		"ds-store": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/ds-store/-/ds-store-0.1.6.tgz",
+			"integrity": "sha1-0QJO90btDBPw9/7IXH6FjoxLfKc=",
+			"optional": true,
+			"requires": {
+				"bplist-creator": "0.0.7",
+				"macos-alias": "0.2.11",
+				"tn1150": "0.1.0"
+			}
+		},
 		"duplexer2": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -2473,122 +2694,75 @@
 				}
 			}
 		},
-		"electron-installer-debian": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/electron-installer-debian/-/electron-installer-debian-0.6.0.tgz",
-			"integrity": "sha1-QkIL367JMLw2vHP5mhW4dDngdrM=",
-			"optional": true,
-			"requires": {
-				"asar": "0.13.1",
-				"async": "2.5.0",
-				"debug": "3.1.0",
-				"fs-extra": "4.0.2",
-				"get-folder-size": "1.0.0",
-				"glob": "7.1.2",
-				"lodash": "4.17.4",
-				"mkdirp": "0.5.1",
-				"temp": "0.8.3",
-				"word-wrap": "1.2.3",
-				"yargs": "9.0.1"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-					"optional": true
-				},
-				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"optional": true,
-					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
-					},
-					"dependencies": {
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-							"optional": true,
-							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
-							}
-						}
-					}
-				},
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"fs-extra": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-					"integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-					"optional": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "4.0.0",
-						"universalify": "0.1.1"
-					}
-				},
-				"jsonfile": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-					"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-					"optional": true,
-					"requires": {
-						"graceful-fs": "4.1.11"
-					}
-				},
-				"yargs": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-					"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
-					"optional": true,
-					"requires": {
-						"camelcase": "4.1.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"read-pkg-up": "2.0.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "7.0.0"
-					}
-				}
-			}
-		},
 		"electron-installer-dmg": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/electron-installer-dmg/-/electron-installer-dmg-0.2.1.tgz",
 			"integrity": "sha1-3oNfAgCbg/guQIA2rDFGLD1sskk=",
 			"optional": true,
 			"requires": {
+				"appdmg": "0.4.5",
 				"debug": "2.6.9",
 				"minimist": "1.2.0"
 			},
 			"dependencies": {
+				"appdmg": {
+					"version": "0.4.5",
+					"resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.4.5.tgz",
+					"integrity": "sha1-R6gnhluKC+SKuzUiVn40k9LxuDg=",
+					"optional": true,
+					"requires": {
+						"async": "1.5.2",
+						"cp-file": "3.2.0",
+						"ds-store": "0.1.6",
+						"execa": "0.4.0",
+						"fs-temp": "1.1.2",
+						"fs-xattr": "0.1.17",
+						"image-size": "0.5.5",
+						"is-my-json-valid": "2.17.2",
+						"minimist": "1.2.0",
+						"parse-color": "1.0.0",
+						"repeat-string": "1.6.1"
+					}
+				},
+				"async": {
+					"version": "1.5.2",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"optional": true
+				},
+				"execa": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
+					"integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
+					"optional": true,
+					"requires": {
+						"cross-spawn-async": "2.2.5",
+						"is-stream": "1.1.0",
+						"npm-run-path": "1.0.0",
+						"object-assign": "4.1.1",
+						"path-key": "1.0.0",
+						"strip-eof": "1.0.0"
+					}
+				},
 				"minimist": {
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"optional": true
+				},
+				"npm-run-path": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+					"integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
+					"optional": true,
+					"requires": {
+						"path-key": "1.0.0"
+					}
+				},
+				"path-key": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+					"integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68="
 				}
 			}
 		},
@@ -3166,6 +3340,7 @@
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+			"dev": true,
 			"requires": {
 				"cross-spawn": "5.1.0",
 				"get-stream": "3.0.0",
@@ -3484,6 +3659,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+			"dev": true,
 			"requires": {
 				"locate-path": "2.0.0"
 			}
@@ -3520,6 +3696,15 @@
 			"requires": {
 				"inherits": "2.0.3",
 				"readable-stream": "2.3.3"
+			}
+		},
+		"fmix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/fmix/-/fmix-0.1.0.tgz",
+			"integrity": "sha1-x7vxJN7ELJ0ZHPuUfQqXeN2YbAw=",
+			"optional": true,
+			"requires": {
+				"imul": "1.0.1"
 			}
 		},
 		"for-in": {
@@ -3592,6 +3777,15 @@
 				"rimraf": "2.6.2"
 			}
 		},
+		"fs-temp": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.1.2.tgz",
+			"integrity": "sha1-zFLwOLvv5RD2vNCexZK3nQ9pJT8=",
+			"optional": true,
+			"requires": {
+				"random-path": "0.1.1"
+			}
+		},
 		"fs-write-stream-atomic": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
@@ -3604,10 +3798,556 @@
 				"readable-stream": "2.3.3"
 			}
 		},
+		"fs-xattr": {
+			"version": "0.1.17",
+			"resolved": "https://registry.npmjs.org/fs-xattr/-/fs-xattr-0.1.17.tgz",
+			"integrity": "sha512-SpBbnN1lkSgBjELpnxnxfcl236ceCu6LnrfrT4CREsux4LP4PvKU37IpceJqAInnTTOWmeVHi9c8lKXIdfynPg==",
+			"optional": true,
+			"requires": {
+				"buffer-from": "0.1.1",
+				"nan": "2.7.0"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fsevents": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
+			"integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"nan": "2.10.0",
+				"node-pre-gyp": "0.9.1"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"aproba": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"delegates": "1.0.0",
+						"readable-stream": "2.3.6"
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"balanced-match": "1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"chownr": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"debug": {
+					"version": "2.6.9",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"detect-libc": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"fs-minipass": {
+					"version": "1.2.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minipass": "2.2.4"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"aproba": "1.2.0",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"iconv-lite": {
+					"version": "0.4.21",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safer-buffer": "2.1.2"
+					}
+				},
+				"ignore-walk": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minimatch": "3.0.4"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true,
+					"dev": true
+				},
+				"ini": {
+					"version": "1.3.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"brace-expansion": "1.1.11"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true,
+					"dev": true
+				},
+				"minipass": {
+					"version": "2.2.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
+					}
+				},
+				"minizlib": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minipass": "2.2.4"
+					}
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"nan": {
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+					"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+					"dev": true,
+					"optional": true
+				},
+				"needle": {
+					"version": "2.2.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"debug": "2.6.9",
+						"iconv-lite": "0.4.21",
+						"sax": "1.2.4"
+					}
+				},
+				"node-pre-gyp": {
+					"version": "0.9.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "1.0.3",
+						"mkdirp": "0.5.1",
+						"needle": "2.2.0",
+						"nopt": "4.0.1",
+						"npm-packlist": "1.1.10",
+						"npmlog": "4.1.2",
+						"rc": "1.2.6",
+						"rimraf": "2.6.2",
+						"semver": "5.5.0",
+						"tar": "4.4.1"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
+					}
+				},
+				"npm-bundled": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"npm-packlist": {
+					"version": "1.1.10",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"ignore-walk": "3.0.1",
+						"npm-bundled": "1.0.3"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.5",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "0.4.2",
+						"ini": "1.3.5",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.3.6",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"bundled": true,
+					"dev": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"sax": {
+					"version": "1.2.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"semver": {
+					"version": "5.5.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "4.4.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"chownr": "1.0.1",
+						"fs-minipass": "1.2.5",
+						"minipass": "2.2.4",
+						"minizlib": "1.1.0",
+						"mkdirp": "0.5.1",
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"string-width": "1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true,
+					"dev": true
+				},
+				"yallist": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true
+				}
+			}
 		},
 		"fstream": {
 			"version": "1.0.11",
@@ -3665,34 +4405,26 @@
 				"globule": "1.2.0"
 			}
 		},
+		"generate-function": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+			"optional": true
+		},
+		"generate-object-property": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+			"optional": true,
+			"requires": {
+				"is-property": "1.0.2"
+			}
+		},
 		"get-caller-file": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-		},
-		"get-folder-size": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-1.0.0.tgz",
-			"integrity": "sha1-E01mOg50VhG3L3HIOxPxsS8xuik=",
-			"optional": true,
-			"requires": {
-				"async": "1.5.2",
-				"minimist": "1.2.0"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-					"optional": true
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-					"optional": true
-				}
-			}
+			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+			"dev": true
 		},
 		"get-package-info": {
 			"version": "1.0.0",
@@ -3723,7 +4455,8 @@
 		"get-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+			"dev": true
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -4160,7 +4893,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz",
 			"integrity": "sha512-HtRQTYpRFz/YVaQ7jh2mU5iorMAxFcML9FNOLMI1f8VNJ2K0hpOlXoi1a+nmVl6oUcGnhd6zYOFAVe7NUFStyQ==",
-			"dev": true,
 			"requires": {
 				"cached-constructors-x": "1.0.0",
 				"to-object-x": "1.5.0",
@@ -4170,14 +4902,12 @@
 		"has-symbol-support-x": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz",
-			"integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA==",
-			"dev": true
+			"integrity": "sha512-JkaetveU7hFbqnAC1EV1sF4rlojU2D4Usc5CmS69l6NfmPDnpnFUegzFg33eDkkpNCxZ0mQp65HwUDrNFS/8MA=="
 		},
 		"has-to-string-tag-x": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
 			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-			"dev": true,
 			"requires": {
 				"has-symbol-support-x": "1.4.1"
 			}
@@ -4541,6 +5271,18 @@
 			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 			"dev": true
 		},
+		"ignore": {
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+			"integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+			"dev": true
+		},
+		"image-size": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+			"integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+			"optional": true
+		},
 		"imagemin": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/imagemin/-/imagemin-5.3.1.tgz",
@@ -4635,6 +5377,11 @@
 				"resolve-cwd": "2.0.0"
 			}
 		},
+		"imul": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
+			"integrity": "sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk="
+		},
 		"imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -4670,8 +5417,7 @@
 		"infinity-x": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/infinity-x/-/infinity-x-1.0.0.tgz",
-			"integrity": "sha512-wjy2TupBtZ+aAniKt+xs/PO0xOkuaL6wBysUKbgD7aL1PMW/qY5xXDG59zXZ7dU+gk3zwXOu4yIEWPCEFBTgHQ==",
-			"dev": true
+			"integrity": "sha512-wjy2TupBtZ+aAniKt+xs/PO0xOkuaL6wBysUKbgD7aL1PMW/qY5xXDG59zXZ7dU+gk3zwXOu4yIEWPCEFBTgHQ=="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -4710,7 +5456,8 @@
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"dev": true
 		},
 		"ip": {
 			"version": "1.1.5",
@@ -4749,7 +5496,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz",
 			"integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
-			"dev": true,
 			"requires": {
 				"attempt-x": "1.1.1",
 				"has-to-string-tag-x": "1.4.1",
@@ -4801,8 +5547,7 @@
 		"is-date-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-			"dev": true
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
 		},
 		"is-directory": {
 			"version": "0.3.1",
@@ -4841,7 +5586,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-falsey-x/-/is-falsey-x-1.0.1.tgz",
 			"integrity": "sha512-XWNZC4A+3FX1ECoMjspuEFgSdio82IWjqY/suE0gZ10QA7nzHd/KraRq7Tc5VEHtFRgTRyTdY6W+ykPrDnyoAQ==",
-			"dev": true,
 			"requires": {
 				"to-boolean-x": "1.0.1"
 			}
@@ -4858,7 +5602,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/is-finite-x/-/is-finite-x-3.0.2.tgz",
 			"integrity": "sha512-HyFrxJZsgmP5RtR1PVlVvHSP4VslZOqr4uoq4x3rDrSOFaYp4R9tfmiWtAzQxPzixXhac3cYEno3NuVn0OHk2Q==",
-			"dev": true,
 			"requires": {
 				"infinity-x": "1.0.0",
 				"is-nan-x": "1.0.1"
@@ -4876,7 +5619,6 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
 			"integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
-			"dev": true,
 			"requires": {
 				"attempt-x": "1.1.1",
 				"has-to-string-tag-x": "1.4.1",
@@ -4913,7 +5655,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz",
 			"integrity": "sha512-qULKLMepQLGC8rSVdi8uF2vI4LiDrU9XSDg1D+Aa657GIB7GV1jHpga7uXgQvkt/cpQ5mVBHUFTpSehYSqT6+A==",
-			"dev": true,
 			"requires": {
 				"math-clamp-x": "1.2.0",
 				"max-safe-integer": "1.0.1",
@@ -4928,11 +5669,29 @@
 			"integrity": "sha1-KVnBfnNDDbOCZNp1uQ3VTy2G2hw=",
 			"dev": true
 		},
+		"is-my-ip-valid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+			"optional": true
+		},
+		"is-my-json-valid": {
+			"version": "2.17.2",
+			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+			"integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+			"optional": true,
+			"requires": {
+				"generate-function": "2.0.0",
+				"generate-object-property": "1.2.0",
+				"is-my-ip-valid": "1.0.0",
+				"jsonpointer": "4.0.1",
+				"xtend": "4.0.1"
+			}
+		},
 		"is-nan-x": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-nan-x/-/is-nan-x-1.0.1.tgz",
-			"integrity": "sha512-VfNJgfuT8USqKCYQss8g7sFvCzDnL+OOVMQoXhVoulZAyp0ZTj3oyZaaPrn2dxepAkKSQI2BiKHbBabX1DqVtw==",
-			"dev": true
+			"integrity": "sha512-VfNJgfuT8USqKCYQss8g7sFvCzDnL+OOVMQoXhVoulZAyp0ZTj3oyZaaPrn2dxepAkKSQI2BiKHbBabX1DqVtw=="
 		},
 		"is-natural-number": {
 			"version": "2.1.1",
@@ -4944,7 +5703,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/is-nil-x/-/is-nil-x-1.4.1.tgz",
 			"integrity": "sha512-cfTKWI5iSR04SSCzzugTH5tS2rYG7kwI8yl/AqWkyuxZ7k55cbA47Y7Lezdg1N9aaELd+UxLg628bdQeNQ6BUw==",
-			"dev": true,
 			"requires": {
 				"lodash.isnull": "3.0.0",
 				"validate.io-undefined": "1.0.3"
@@ -4969,7 +5727,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/is-object-like-x/-/is-object-like-x-1.6.0.tgz",
 			"integrity": "sha512-mc3dBMv1jEOdk0f1i2RkJFsZDux0MuHqGwHOoRo770ShUOf4VE6tWThAW8dAZARr9a5RN+iNX1yzMDA5ad1clQ==",
-			"dev": true,
 			"requires": {
 				"is-function-x": "3.3.0",
 				"is-primitive": "2.0.0"
@@ -5037,8 +5794,13 @@
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+		},
+		"is-property": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+			"optional": true
 		},
 		"is-redirect": {
 			"version": "1.0.0",
@@ -5075,8 +5837,7 @@
 		"is-string": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-			"integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
-			"dev": true
+			"integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
 		},
 		"is-svg": {
 			"version": "2.1.0",
@@ -5090,8 +5851,7 @@
 		"is-symbol": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-			"dev": true
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
 		},
 		"is-tar": {
 			"version": "1.0.0",
@@ -5259,6 +6019,12 @@
 			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
 			"dev": true
 		},
+		"jsonpointer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+			"optional": true
+		},
 		"jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5312,6 +6078,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"dev": true,
 			"requires": {
 				"invert-kv": "1.0.0"
 			}
@@ -5320,6 +6087,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
 			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"parse-json": "2.2.0",
@@ -5348,6 +6116,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+			"dev": true,
 			"requires": {
 				"p-locate": "2.0.0",
 				"path-exists": "3.0.0"
@@ -5356,7 +6125,8 @@
 		"lodash": {
 			"version": "4.17.4",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+			"dev": true
 		},
 		"lodash._baseassign": {
 			"version": "3.2.0",
@@ -5498,8 +6268,7 @@
 		"lodash.isnull": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/lodash.isnull/-/lodash.isnull-3.0.0.tgz",
-			"integrity": "sha1-+vvlnqHcon7teGU0A53YTC4HxW4=",
-			"dev": true
+			"integrity": "sha1-+vvlnqHcon7teGU0A53YTC4HxW4="
 		},
 		"lodash.keys": {
 			"version": "3.1.2",
@@ -5639,6 +6408,15 @@
 			"integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
 			"dev": true
 		},
+		"macos-alias": {
+			"version": "0.2.11",
+			"resolved": "https://registry.npmjs.org/macos-alias/-/macos-alias-0.2.11.tgz",
+			"integrity": "sha1-/u6mwTuhGYFKQ/xDxHCzHlnvcYo=",
+			"optional": true,
+			"requires": {
+				"nan": "2.7.0"
+			}
+		},
 		"make-dir": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
@@ -5665,7 +6443,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
 			"integrity": "sha512-tqpjpBcIf9UulApz3EjWXqTZpMlr2vLN9PryC9ghoyCuRmqZaf3JJhPddzgQpJnKLi2QhoFnvKBFtJekAIBSYg==",
-			"dev": true,
 			"requires": {
 				"to-number-x": "2.0.0"
 			}
@@ -5680,7 +6457,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz",
 			"integrity": "sha512-OzPas41Pn4d16KHnaXmGxxY3/l3zK4OIXtmIwdhgZsxz4FDDcNnbrABYPg2vGfxIkaT9ezGnzDviRH7RfF44jQ==",
-			"dev": true,
 			"requires": {
 				"is-nan-x": "1.0.1",
 				"to-number-x": "2.0.0"
@@ -5689,8 +6465,7 @@
 		"max-safe-integer": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/max-safe-integer/-/max-safe-integer-1.0.1.tgz",
-			"integrity": "sha1-84BgvixWPYwC5tSK85Ei/YO29BA=",
-			"dev": true
+			"integrity": "sha1-84BgvixWPYwC5tSK85Ei/YO29BA="
 		},
 		"md5.js": {
 			"version": "1.3.4",
@@ -5730,6 +6505,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+			"dev": true,
 			"requires": {
 				"mimic-fn": "1.1.0"
 			}
@@ -5908,7 +6684,8 @@
 		"mimic-fn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+			"dev": true
 		},
 		"minimalistic-assert": {
 			"version": "1.0.0",
@@ -6110,17 +6887,26 @@
 				}
 			}
 		},
+		"murmur-32": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/murmur-32/-/murmur-32-0.1.0.tgz",
+			"integrity": "sha1-waedT8X6vwQFdJ0K/3fEFAIFWGE=",
+			"optional": true,
+			"requires": {
+				"array-buffer-from-string": "0.1.0",
+				"fmix": "0.1.0",
+				"imul": "1.0.1"
+			}
+		},
 		"nan": {
 			"version": "2.7.0",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
-			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
-			"dev": true
+			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
 		},
 		"nan-x": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/nan-x/-/nan-x-1.0.0.tgz",
-			"integrity": "sha512-yw4Fhe2/UTzanQ4f0yHWkRnfTuHZFAi4GZDjXS4G+qv5BqXTqPJBbSxpa7MyyW9v4Y4ZySZQik1vcbNkhdnIOg==",
-			"dev": true
+			"integrity": "sha512-yw4Fhe2/UTzanQ4f0yHWkRnfTuHZFAi4GZDjXS4G+qv5BqXTqPJBbSxpa7MyyW9v4Y4ZySZQik1vcbNkhdnIOg=="
 		},
 		"ncname": {
 			"version": "1.0.0",
@@ -6136,6 +6922,15 @@
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
 			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
 			"dev": true
+		},
+		"nested-error-stacks": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.2.tgz",
+			"integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
+			"optional": true,
+			"requires": {
+				"inherits": "2.0.3"
+			}
 		},
 		"no-case": {
 			"version": "2.3.2",
@@ -6336,7 +7131,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
 			"integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
-			"dev": true,
 			"requires": {
 				"cached-constructors-x": "1.0.0",
 				"trim-x": "3.0.0",
@@ -6359,6 +7153,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+			"dev": true,
 			"requires": {
 				"path-key": "2.0.1"
 			}
@@ -6430,7 +7225,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/object-get-own-property-descriptor-x/-/object-get-own-property-descriptor-x-3.2.0.tgz",
 			"integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
-			"dev": true,
 			"requires": {
 				"attempt-x": "1.1.1",
 				"has-own-property-x": "3.2.0",
@@ -6595,6 +7389,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+			"dev": true,
 			"requires": {
 				"execa": "0.7.0",
 				"lcid": "1.0.0",
@@ -6619,17 +7414,20 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+			"dev": true
 		},
 		"p-limit": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+			"dev": true
 		},
 		"p-locate": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+			"dev": true,
 			"requires": {
 				"p-limit": "1.1.0"
 			}
@@ -6694,6 +7492,23 @@
 				"author-regex": "1.0.0"
 			}
 		},
+		"parse-color": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/parse-color/-/parse-color-1.0.0.tgz",
+			"integrity": "sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=",
+			"optional": true,
+			"requires": {
+				"color-convert": "0.5.3"
+			},
+			"dependencies": {
+				"color-convert": {
+					"version": "0.5.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+					"integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
+					"optional": true
+				}
+			}
+		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -6710,7 +7525,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
 			"integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
-			"dev": true,
 			"requires": {
 				"cached-constructors-x": "1.0.0",
 				"nan-x": "1.0.0",
@@ -6747,7 +7561,8 @@
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -6763,7 +7578,8 @@
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.5",
@@ -6781,6 +7597,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
 			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+			"dev": true,
 			"requires": {
 				"pify": "2.3.0"
 			}
@@ -7530,7 +8347,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
 			"integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
-			"dev": true,
 			"requires": {
 				"to-object-x": "1.5.0",
 				"to-property-key-x": "2.0.2"
@@ -7665,6 +8481,16 @@
 			"integrity": "sha1-DPf4T5Rj/wrlHExLFC2VvjdyTZw=",
 			"dev": true
 		},
+		"random-path": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/random-path/-/random-path-0.1.1.tgz",
+			"integrity": "sha1-+PTTb3WhNMoV/TnH11BfvxY7Y0w=",
+			"optional": true,
+			"requires": {
+				"base32-encode": "0.1.1",
+				"murmur-32": "0.1.0"
+			}
+		},
 		"randomatic": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -7777,6 +8603,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
 			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+			"dev": true,
 			"requires": {
 				"load-json-file": "2.0.0",
 				"normalize-package-data": "2.4.0",
@@ -7787,6 +8614,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
 			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+			"dev": true,
 			"requires": {
 				"find-up": "2.1.0",
 				"read-pkg": "2.0.0"
@@ -7972,8 +8800,7 @@
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"repeating": {
 			"version": "2.0.1",
@@ -7987,7 +8814,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
 			"integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
-			"dev": true,
 			"requires": {
 				"require-coercible-to-string-x": "1.0.0",
 				"to-string-x": "1.4.2"
@@ -8032,7 +8858,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/require-coercible-to-string-x/-/require-coercible-to-string-x-1.0.0.tgz",
 			"integrity": "sha512-Rpfd4sMdflPAKecdKhfAtQHlZzzle4UMUgxJ01hXtTcNWMV8w9GeZnKhEyrT73kgrflBOP1zg41amUPZGcNspA==",
-			"dev": true,
 			"requires": {
 				"require-object-coercible-x": "1.4.1",
 				"to-string-x": "1.4.2"
@@ -8041,7 +8866,8 @@
 		"require-directory": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
 		},
 		"require-from-string": {
 			"version": "1.2.1",
@@ -8052,13 +8878,13 @@
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+			"dev": true
 		},
 		"require-object-coercible-x": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/require-object-coercible-x/-/require-object-coercible-x-1.4.1.tgz",
 			"integrity": "sha512-0YHa2afepsLfQvwQ1P2XvDZnGOUia5sC07ZijIRU2dnsRxnuilXWF6B2CFaKGDA9eZl39lJHrXCDsnfgroRd6Q==",
-			"dev": true,
 			"requires": {
 				"is-nil-x": "1.4.1"
 			}
@@ -8511,6 +9337,12 @@
 				"statuses": "1.3.1"
 			}
 		},
+		"serialize-javascript": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
+			"integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
+			"dev": true
+		},
 		"serve-index": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
@@ -8541,7 +9373,8 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"set-immediate-shim": {
 			"version": "1.0.1",
@@ -8604,6 +9437,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+			"dev": true,
 			"requires": {
 				"shebang-regex": "1.0.0"
 			}
@@ -8611,7 +9445,8 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+			"dev": true
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -8637,6 +9472,12 @@
 					}
 				}
 			}
+		},
+		"slash": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+			"dev": true
 		},
 		"sntp": {
 			"version": "2.1.0",
@@ -8906,6 +9747,12 @@
 				"readable-stream": "2.3.3"
 			}
 		},
+		"stream-buffers": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+			"integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=",
+			"optional": true
+		},
 		"stream-combiner2": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
@@ -8955,6 +9802,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
 			"requires": {
 				"is-fullwidth-code-point": "2.0.0",
 				"strip-ansi": "4.0.0"
@@ -8963,17 +9811,20 @@
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
 				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
 					"requires": {
 						"ansi-regex": "3.0.0"
 					}
@@ -9004,7 +9855,8 @@
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+			"dev": true
 		},
 		"strip-bom-stream": {
 			"version": "1.0.0",
@@ -9381,8 +10233,18 @@
 			"version": "0.0.28",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
 			"integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
+			"dev": true,
 			"requires": {
 				"os-tmpdir": "1.0.2"
+			}
+		},
+		"tn1150": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/tn1150/-/tn1150-0.1.0.tgz",
+			"integrity": "sha1-ZzUD0k1WuH3ouMd/7j/AhT1ZoY0=",
+			"optional": true,
+			"requires": {
+				"unorm": "1.4.1"
 			}
 		},
 		"to-absolute-glob": {
@@ -9403,14 +10265,12 @@
 		"to-boolean-x": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/to-boolean-x/-/to-boolean-x-1.0.1.tgz",
-			"integrity": "sha512-PstxY3K6hVEHnY3FITs8XBoJbt0RI1e4MLIhAL9hWa3BtVLCrb86vU5z6lEKh7uZZjiPiLqIKMmfMro1nNgtXQ==",
-			"dev": true
+			"integrity": "sha512-PstxY3K6hVEHnY3FITs8XBoJbt0RI1e4MLIhAL9hWa3BtVLCrb86vU5z6lEKh7uZZjiPiLqIKMmfMro1nNgtXQ=="
 		},
 		"to-integer-x": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz",
 			"integrity": "sha512-794L2Lpwjtynm7RxahJi2YdbRY75gTxUW27TMuN26UgwPkmJb/+HPhkFEFbz+E4vNoiP0dxq5tq5fkXoXLaK/w==",
-			"dev": true,
 			"requires": {
 				"is-finite-x": "3.0.2",
 				"is-nan-x": "1.0.1",
@@ -9422,7 +10282,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
 			"integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
-			"dev": true,
 			"requires": {
 				"cached-constructors-x": "1.0.0",
 				"nan-x": "1.0.0",
@@ -9435,7 +10294,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
 			"integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
-			"dev": true,
 			"requires": {
 				"cached-constructors-x": "1.0.0",
 				"require-object-coercible-x": "1.4.1"
@@ -9445,7 +10303,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
 			"integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
-			"dev": true,
 			"requires": {
 				"has-symbol-support-x": "1.4.1",
 				"is-date-object": "1.0.1",
@@ -9461,7 +10318,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
 			"integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
-			"dev": true,
 			"requires": {
 				"has-symbol-support-x": "1.4.1",
 				"to-primitive-x": "1.1.0",
@@ -9472,7 +10328,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/to-string-symbols-supported-x/-/to-string-symbols-supported-x-1.0.0.tgz",
 			"integrity": "sha512-HbVH673pybrUmhzESGHUm17BBJvqb7BU8HciOvuEYm9ipuDyjmddhvkVqpVW6sM/C5/zhJo17n7O7I/24loJIQ==",
-			"dev": true,
 			"requires": {
 				"cached-constructors-x": "1.0.0",
 				"has-symbol-support-x": "1.4.1",
@@ -9483,7 +10338,6 @@
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/to-string-tag-x/-/to-string-tag-x-1.4.2.tgz",
 			"integrity": "sha512-ytO9eLigxsQQLGuab0C1iSSTzKdJNVSlBg0Spg4J/rGAVrQJ5y774mo0SSzgGeTT4RJGGyJNfObXaTMzX0XDOQ==",
-			"dev": true,
 			"requires": {
 				"lodash.isnull": "3.0.0",
 				"validate.io-undefined": "1.0.3"
@@ -9493,7 +10347,6 @@
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/to-string-x/-/to-string-x-1.4.2.tgz",
 			"integrity": "sha512-/WP5arlwtCpAAexCCHiQBW0eXwse84osWyP1Qtaz71nsYSuUpOkT6tBm8nQ4IIUfSh5hji0hDupUCD2xbbOL6A==",
-			"dev": true,
 			"requires": {
 				"is-symbol": "1.0.1"
 			}
@@ -9545,7 +10398,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
 			"integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
-			"dev": true,
 			"requires": {
 				"cached-constructors-x": "1.0.0",
 				"require-coercible-to-string-x": "1.0.0",
@@ -9570,7 +10422,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
 			"integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
-			"dev": true,
 			"requires": {
 				"cached-constructors-x": "1.0.0",
 				"require-coercible-to-string-x": "1.0.0",
@@ -9581,7 +10432,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
 			"integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
-			"dev": true,
 			"requires": {
 				"trim-left-x": "3.0.0",
 				"trim-right-x": "3.0.0"
@@ -9776,7 +10626,14 @@
 		"universalify": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
+			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+			"dev": true
+		},
+		"unorm": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
+			"integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA=",
+			"optional": true
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -9946,8 +10803,7 @@
 		"validate.io-undefined": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/validate.io-undefined/-/validate.io-undefined-1.0.3.tgz",
-			"integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q=",
-			"dev": true
+			"integrity": "sha1-fif8uzFbhB54JDQxiXZxkp4gt/Q="
 		},
 		"vary": {
 			"version": "1.1.2",
@@ -10399,13 +11255,13 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
 		},
 		"white-space-x": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/white-space-x/-/white-space-x-3.0.0.tgz",
-			"integrity": "sha512-nMPVXGMdi/jQepXKryxqzEh/vCwdOYY/u6NZy40glMHvZfEr7/+vQKnDhEq4rZ1nniOFq9GWohQYB30uW/5Olg==",
-			"dev": true
+			"integrity": "sha512-nMPVXGMdi/jQepXKryxqzEh/vCwdOYY/u6NZy40glMHvZfEr7/+vQKnDhEq4rZ1nniOFq9GWohQYB30uW/5Olg=="
 		},
 		"wide-align": {
 			"version": "1.1.2",
@@ -10435,12 +11291,6 @@
 			"integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
 			"dev": true
 		},
-		"word-wrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-			"optional": true
-		},
 		"wordwrap": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
@@ -10461,6 +11311,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"dev": true,
 			"requires": {
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1"
@@ -10470,6 +11321,7 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
 					"requires": {
 						"code-point-at": "1.1.0",
 						"is-fullwidth-code-point": "1.0.0",
@@ -10521,13 +11373,13 @@
 		"xtend": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-			"dev": true
+			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"dev": true
 		},
 		"yallist": {
 			"version": "2.1.2",
@@ -10591,6 +11443,7 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
 			"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+			"dev": true,
 			"requires": {
 				"camelcase": "4.1.0"
 			},
@@ -10598,7 +11451,8 @@
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+					"dev": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
 	],
 	"author": "BASSIN Laurent & MARQUET Maxime",
 	"license": "MIT",
-	"main": "dist/electron.js",
+	"main": "electron.js",
 	"scripts": {
-		"dev": "tsc electron.ts --outDir ./dist && cross-env NODE_ENV=dev webpack-dev-server --port=4200",
-		"prod": "webpack && electron .",
+		"dev": "tsc electron.ts --outDir . && cross-env NODE_ENV=dev webpack-dev-server --port=4200",
+		"prod": "webpack && electron dist/electron.js",
 		"packager:win": "cross-env NODE_OS=win node builder/packager.js",
 		"packager:mac": "cross-env NODE_OS=mac node builder/packager.js",
 		"packager:linux": "cross-env NODE_OS=linux node builder/packager.js",
@@ -32,6 +32,7 @@
 	"devDependencies": {
 		"clean-webpack-plugin": "^0.1.17",
 		"concurrently": "^3.5.0",
+		"copy-webpack-plugin": "^4.5.1",
 		"cross-env": "^5.1.1",
 		"css-loader": "^0.28.7",
 		"electron-packager": "^9.1.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,8 +3,9 @@ const path = require('path');
 const Webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const exec = require('child_process').exec;
-const UglifyJs = require('uglifyjs-webpack-plugin');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 // Html-webpack-plugin configuration
 const indexConfig = {
@@ -47,74 +48,72 @@ let webpackConfig = {
     },
     // How the different types of modules within a project will be treated
     module: {
-        rules: [
-            {
-                // All files with a '.ts' extension will be handled by ts-loader
-                test: /\.ts$/,
-                use: 'ts-loader',
-                exclude: /node_modules/
-            }, {
-                // All files with a '.scss' extension will be handled by sass-loader
-                test: /\.s?css$/,
-                use: [{
+        rules: [{
+            // All files with a '.ts' extension will be handled by ts-loader
+            test: /\.ts$/,
+            use: 'ts-loader',
+            exclude: /node_modules/
+        }, {
+            // All files with a '.scss' extension will be handled by sass-loader
+            test: /\.s?css$/,
+            use: [{
                     loader: 'file-loader',
                     options: {
                         name: '[name].[hash:10].css'
                     }
                 },
-                    'extract-loader',
-                    {
-                        loader: 'css-loader',
-                        options: {
-                            minimize: !dev
-                        }
-                    },
-                    {
-                        loader: 'postcss-loader',
-                        options: {
-                            sourceMap: dev
-                        }
-                    },
-                    'resolve-url-loader',
-                    'sass-loader'
-                ],
-            }, {
-                // All files with a '.html' extension will be handled by html-loader and save into external file
-                test: /\.html$/,
-                exclude: /node_modules/,
-                use: [{
+                'extract-loader',
+                {
+                    loader: 'css-loader',
+                    options: {
+                        minimize: !dev
+                    }
+                },
+                {
+                    loader: 'postcss-loader',
+                    options: {
+                        sourceMap: dev
+                    }
+                },
+                'resolve-url-loader',
+                'sass-loader'
+            ],
+        }, {
+            // All files with a '.html' extension will be handled by html-loader and save into external file
+            test: /\.html$/,
+            exclude: /node_modules/,
+            use: [{
                     loader: 'file-loader',
                     options: {
                         name: '[name].[hash:10].html',
                     }
                 },
-                    'extract-loader',
-                    'html-loader'
-                ]
+                'extract-loader',
+                'html-loader'
+            ]
+        }, {
+            // All images and fonts will be optimized and their paths will be solved
+            enforce: 'pre',
+            test: /\.(png|jpe?g|gif|svg|woff2?|eot|ttf|otf|wav)(\?.*)?$/,
+            use: [{
+                loader: 'url-loader',
+                options: {
+                    name: '[name].[hash:10].[ext]',
+                    limit: 8192
+                }
             }, {
-                // All images and fonts will be optimized and their paths will be solved
-                enforce: 'pre',
-                test: /\.(png|jpe?g|gif|svg|woff2?|eot|ttf|otf|wav)(\?.*)?$/,
-                use: [{
-                    loader: 'url-loader',
-                    options: {
-                        name: '[name].[hash:10].[ext]',
-                        limit: 8192
-                    }
-                }, {
-                    loader: 'img-loader'
-                }],
-            }, {
-                test: /\.hbs$/,
-                exclude: /node_modules/,
-                use: {
-                    loader: 'underscore-template-loader',
-                    query: {
-                        attributes: ['img:src', 'link:href']
-                    }
+                loader: 'img-loader'
+            }],
+        }, {
+            test: /\.hbs$/,
+            exclude: /node_modules/,
+            use: {
+                loader: 'underscore-template-loader',
+                query: {
+                    attributes: ['img:src', 'link:href']
                 }
             }
-        ]
+        }]
     },
     // Configure how modules are resolved
     resolve: {
@@ -139,13 +138,14 @@ let webpackConfig = {
     plugins: [
         new HtmlWebpackPlugin(indexConfig),
         new Webpack.ContextReplacementPlugin(/angular([\\\/])core([\\\/])/, path.resolve(__dirname, './src')),
+        new CopyWebpackPlugin(['./package.json']),
     ],
 };
 
 // UglifyJs and clean output folder only for prod
 if (!dev) {
     webpackConfig.plugins.push(new CleanWebpackPlugin(pathsToClean));
-    webpackConfig.plugins.push(new UglifyJs());
+    webpackConfig.plugins.push(new UglifyJsPlugin());
 }
 
 // Export the config


### PR DESCRIPTION
By configuring `electron-packager` packs only compiled code in `dist` folder. We have a new package installer with smaller size and securce application (from 130MB down to ~52MB). That is awesome!

Some changes in this PR:

* Configure packager packs only compiled source code
* Copy `package.json` to distribution output folder that required by `electron` to start the application
* Refactor name of webpack plugin `UglifyJsPlugin` and reformat code

I hope this will fix #4.